### PR TITLE
optimized squaring code (Removed redundant <0 check)

### DIFF
--- a/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/LinearOp.java
+++ b/FtcRobotController/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/LinearOp.java
@@ -686,10 +686,6 @@ public class LinearOp extends LinearOpMode
         double changeX = startX - endX;
         double changeY = startY - endY;
 
-        if(changeX < 0)
-            changeX *= -1;
-        if(changeY < 0)
-            changeY *= -1;
         dist = (changeX * changeX) + (changeY * changeY);
         dist = Math.sqrt(dist);
         return dist;


### PR DESCRIPTION
Since you're squaring changeX and changeY, you don't need to check if they're less than 0.
